### PR TITLE
Implement Peerconnection::localDescription

### DIFF
--- a/wasm/include/rtc/peerconnection.hpp
+++ b/wasm/include/rtc/peerconnection.hpp
@@ -33,6 +33,29 @@ namespace rtc {
 
 class PeerConnection final {
 public:
+	enum class State : int {
+		New = 0,
+		Connecting = 1,
+		Connected = 2,
+		Disconnected = 3,
+		Failed = 4,
+		Closed = 5
+	};
+
+	enum class GatheringState : int {
+		New = 0,
+		InProgress = 1,
+		Complete = 2
+	};
+
+	enum class SignalingState : int {
+		Stable = 0,
+		HaveLocalOffer = 1,
+		HaveRemoteOffer = 2,
+		HaveLocalPranswer = 3,
+		HaveRemotePranswer = 4,
+	} rtcSignalingState;
+
 	PeerConnection();
 	PeerConnection(const Configuration &config);
 	~PeerConnection();
@@ -45,15 +68,24 @@ public:
 	void onDataChannel(std::function<void(std::shared_ptr<DataChannel>)> callback);
 	void onLocalDescription(std::function<void(const Description &description)> callback);
 	void onLocalCandidate(std::function<void(const Candidate &candidate)> callback);
+	void onStateChange(std::function<void(State state)> callback);
+	void onGatheringStateChange(std::function<void(GatheringState state)> callback);
+	void onSignalingStateChange(std::function<void(SignalingState state)> callback);
 
 protected:
 	void triggerDataChannel(std::shared_ptr<DataChannel> dataChannel);
 	void triggerLocalDescription(const Description &description);
 	void triggerLocalCandidate(const Candidate &candidate);
+	void triggerStateChange(State state);
+	void triggerGatheringStateChange(GatheringState state);
+	void triggerSignalingStateChange(SignalingState state);
 
 	std::function<void(std::shared_ptr<DataChannel>)> mDataChannelCallback;
 	std::function<void(const Description &description)> mLocalDescriptionCallback;
 	std::function<void(const Candidate &candidate)> mLocalCandidateCallback;
+	std::function<void(State candidate)> mStateChangeCallback;
+	std::function<void(GatheringState candidate)> mGatheringStateChangeCallback;
+	std::function<void(SignalingState candidate)> mSignalingStateChangeCallback;
 
 private:
 	int mId;
@@ -61,6 +93,9 @@ private:
 	static void DataChannelCallback(int dc, void *ptr);
 	static void DescriptionCallback(const char *sdp, const char *type, void *ptr);
 	static void CandidateCallback(const char *candidate, const char *mid, void *ptr);
+	static void StateChangeCallback(int state, void *ptr);
+	static void GatheringStateChangeCallback(int state, void *ptr);
+	static void SignalingStateChangeCallback(int state, void *ptr);
 };
 
 } // namespace rtc

--- a/wasm/include/rtc/peerconnection.hpp
+++ b/wasm/include/rtc/peerconnection.hpp
@@ -60,6 +60,8 @@ public:
 	PeerConnection(const Configuration &config);
 	~PeerConnection();
 
+	std::optional<Description> localDescription() const;
+
 	std::shared_ptr<DataChannel> createDataChannel(const string &label);
 
 	void setRemoteDescription(const Description &description);

--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -181,7 +181,7 @@
 			}
 		},
 
-		rtcLocalDescriptionSdp: function(pc) {
+		rtcGetLocalDescription: function(pc) {
 			if(!pc) return 0;
 			var peerConnection = WEBRTC.peerConnectionsMap[pc];
 			var localDescription = peerConnection.localDescription;
@@ -191,7 +191,7 @@
 			return sdp;
 		},
 
-		rtcLocalDescriptionType: function(pc) {
+		rtcGetLocalDescriptionType: function(pc) {
 			if(!pc) return 0;
 			var peerConnection = WEBRTC.peerConnectionsMap[pc];
 			var localDescription = peerConnection.localDescription;

--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -181,6 +181,26 @@
 			}
 		},
 
+		rtcLocalDescriptionSdp: function(pc) {
+			if(!pc) return 0;
+			var peerConnection = WEBRTC.peerConnectionsMap[pc];
+			var localDescription = peerConnection.localDescription;
+			if(!localDescription) return 0;
+			var sdp = WEBRTC.allocUTF8FromString(localDescription.sdp);
+			// sdp should be freed later.
+			return sdp;
+		},
+
+		rtcLocalDescriptionType: function(pc) {
+			if(!pc) return 0;
+			var peerConnection = WEBRTC.peerConnectionsMap[pc];
+			var localDescription = peerConnection.localDescription;
+			if(!localDescription) return 0;
+			var type = WEBRTC.allocUTF8FromString(localDescription.type);
+			// type should be freed later.
+			return type;
+		},
+
 		rtcCreateDataChannel: function(pc, pLabel) {
 			if(!pc) return 0;
 			var label = UTF8ToString(pLabel);

--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -148,6 +148,18 @@
 			peerConnection.rtcCandidateCallback = candidateCallback;
 		},
 
+		rtcSetStateChangeCallback: function(pc, stateChangeCallback) {
+			console.log('rtcSetStateChangeCallback called');
+		},
+
+		rtcSetGatheringStateChangeCallback: function(pc, gatheringStateChangeCallback) {
+			console.log('rtcSetGatheringStateChangeCallback called');
+		},
+
+		rtcSetSignalingStateChangeCallback: function(pc, signalingStateChangeCallback) {
+			console.log('rtcSetSignalingStateChangeCallback called');
+		},
+
 		rtcSetRemoteDescription: function(pc, pSdp, pType) {
 			var description = new RTCSessionDescription({
 				sdp: UTF8ToString(pSdp),

--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -46,6 +46,15 @@
 					if(evt.candidate && evt.candidate.candidate)
 					  WEBRTC.handleCandidate(peerConnection, evt.candidate);
 				};
+				peerConnection.onconnectionstatechange = function(evt) {
+					WEBRTC.handleConnectionStateChange(peerConnection, peerConnection.connectionState)
+				};
+				peerConnection.onicegatheringstatechange = function() {
+					WEBRTC.handleIceGatheringStateChange(peerConnection, peerConnection.iceGatheringState)
+				};
+				peerConnection.onsignalingstatechange = function(evt) {
+					WEBRTC.handleSignalingStateChange(peerConnection, peerConnection.signalingState)
+				};
 				return pc;
 			},
 
@@ -82,6 +91,69 @@
 				Module['dynCall']('viii', candidateCallback, [pCandidate, pSdpMid, userPointer]);
 				_free(pCandidate);
 				_free(pSdpMid);
+			},
+
+			handleConnectionStateChange: function(peerConnection, connectionState) {
+				var stateChangeCallback =  peerConnection.rtcStateChangeCallback;
+				var userPointer = peerConnection.rtcUserPointer || 0;
+				switch(connectionState) {
+					case 'new':
+						Module['dynCall']('vii', stateChangeCallback, [0, userPointer]);
+						break;
+					case 'connecting':
+						Module['dynCall']('vii', stateChangeCallback, [1, userPointer]);
+						break;
+					case 'connected':
+						Module['dynCall']('vii', stateChangeCallback, [2, userPointer]);
+						break;
+					case 'disconnected':
+						Module['dynCall']('vii', stateChangeCallback, [3, userPointer]);
+						break;
+					case 'failed':
+						Module['dynCall']('vii', stateChangeCallback, [4, userPointer]);
+						break;
+					case 'closed':
+						Module['dynCall']('vii', stateChangeCallback, [5, userPointer]);
+						break;
+				}
+			},
+
+			handleIceGatheringStateChange: function(peerConnection, iceGatheringState) {
+				var gatheringStateChangeCallback = peerConnection.rtcGatheringStateChangeCallback;
+				var userPointer = peerConnection.rtcUserPointer || 0;
+				switch(iceGatheringState) {
+					case "new":
+						Module['dynCall']('vii', gatheringStateChangeCallback, [0, userPointer]);
+						break;
+					case "gathering":
+						Module['dynCall']('vii', gatheringStateChangeCallback, [1, userPointer]);
+						break;
+					case "complete":
+						Module['dynCall']('vii', gatheringStateChangeCallback, [2, userPointer]);
+						break;
+				}
+			},
+
+			handleSignalingStateChange: function(peerConnection, signalingState) {
+				var signalingStateChangeCallback = peerConnection.rtcSignalingStateChangeCallback;
+				var userPointer = peerConnection.rtcUserPointer || 0;
+				switch(signalingState) {
+					case "stable":
+						Module['dynCall']('vii', signalingStateChangeCallback, [0, userPointer]);
+						break;
+					case "have-local-offer":
+						Module['dynCall']('vii', signalingStateChangeCallback, [1, userPointer]);
+						break;
+					case "have-remote-offer":
+						Module['dynCall']('vii', signalingStateChangeCallback, [2, userPointer]);
+						break;
+					case "have-local-pranswer":
+						Module['dynCall']('vii', signalingStateChangeCallback, [3, userPointer]);
+						break;
+					case "have-remote-pranswer":
+						Module['dynCall']('vii', signalingStateChangeCallback, [4, userPointer]);
+						break;
+				}
 			},
 		},
 
@@ -149,15 +221,21 @@
 		},
 
 		rtcSetStateChangeCallback: function(pc, stateChangeCallback) {
-			console.log('rtcSetStateChangeCallback called');
+			if(!pc) return;
+			var peerConnection = WEBRTC.peerConnectionsMap[pc];
+			peerConnection.rtcStateChangeCallback = stateChangeCallback;
 		},
 
 		rtcSetGatheringStateChangeCallback: function(pc, gatheringStateChangeCallback) {
-			console.log('rtcSetGatheringStateChangeCallback called');
+			if(!pc) return;
+			var peerConnection = WEBRTC.peerConnectionsMap[pc];
+			peerConnection.rtcGatheringStateChangeCallback = gatheringStateChangeCallback;
 		},
 
 		rtcSetSignalingStateChangeCallback: function(pc, signalingStateChangeCallback) {
-			console.log('rtcSetSignalingStateChangeCallback called');
+			if(!pc) return;
+			var peerConnection = WEBRTC.peerConnectionsMap[pc];
+			peerConnection.rtcSignalingStateChangeCallback = signalingStateChangeCallback;
 		},
 
 		rtcSetRemoteDescription: function(pc, pSdp, pType) {

--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -187,7 +187,7 @@
 			var localDescription = peerConnection.localDescription;
 			if(!localDescription) return 0;
 			var sdp = WEBRTC.allocUTF8FromString(localDescription.sdp);
-			// sdp should be freed later.
+			// sdp should be freed later in c++.
 			return sdp;
 		},
 
@@ -197,7 +197,7 @@
 			var localDescription = peerConnection.localDescription;
 			if(!localDescription) return 0;
 			var type = WEBRTC.allocUTF8FromString(localDescription.type);
-			// type should be freed later.
+			// type should be freed later in c++.
 			return type;
 		},
 

--- a/wasm/src/peerconnection.cpp
+++ b/wasm/src/peerconnection.cpp
@@ -120,7 +120,6 @@ optional<Description> PeerConnection::localDescription() const {
 			free(type);
 		return std::nullopt;
 	}
-	// In the return value of rtcLocalDescription, type comes in front of sdp.
 	Description description(sdp, type);
 	free(sdp);
 	free(type);

--- a/wasm/src/peerconnection.cpp
+++ b/wasm/src/peerconnection.cpp
@@ -27,8 +27,8 @@
 extern "C" {
 extern int rtcCreatePeerConnection(const char **iceServers);
 extern void rtcDeletePeerConnection(int pc);
-extern char *rtcLocalDescriptionSdp(int pc);
-extern char *rtcLocalDescriptionType(int pc);
+extern char *rtcGetLocalDescription(int pc);
+extern char *rtcGetLocalDescriptionType(int pc);
 extern int rtcCreateDataChannel(int pc, const char *label);
 extern void rtcSetDataChannelCallback(int pc, void (*dataChannelCallback)(int, void *));
 extern void rtcSetLocalDescriptionCallback(int pc,
@@ -109,15 +109,11 @@ PeerConnection::PeerConnection(const Configuration &config) {
 PeerConnection::~PeerConnection() { rtcDeletePeerConnection(mId); }
 
 optional<Description> PeerConnection::localDescription() const {
-	// TODO: sdp and type of the local description in acquired by two function calls.
-	// Find a way to reduce this into one call (probably multi-value return may work).
-	char *sdp = rtcLocalDescriptionSdp(mId);
-	char *type = rtcLocalDescriptionType(mId);
+	char *sdp = rtcGetLocalDescription(mId);
+	char *type = rtcGetLocalDescriptionType(mId);
 	if (!sdp || !type) {
-		if (sdp)
-			free(sdp);
-		if (type)
-			free(type);
+		free(sdp);
+		free(type);
 		return std::nullopt;
 	}
 	Description description(sdp, type);


### PR DESCRIPTION
Done on top of #12.

This PR adds Peerconnection::localDescription(). It is implemented with a non-ideal trick of calling two javascript functions--rtcLocalDescriptionSdp and rtcLocalDescriptionType--which introduces some redundancy. Perhaps this can be improved by returning a string array or with use of multi-value return from javascript to c++, which I currently do not know how to implement...