### PR TITLE
Remove wasm options that turned as default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,6 @@ target_include_directories(datachannel-wasm PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/wasm/include/rtc)
 
 set(WASM_OPTS
-	"SHELL:-s WASM=1"
-	"SHELL:-s BINARYEN_METHOD=native-wasm"
 	"SHELL:-s EXPORTED_RUNTIME_METHODS=[\"dynCall\"]")
 
 target_compile_options(datachannel-wasm PUBLIC ${WASM_OPTS})


### PR DESCRIPTION
According to the following, these two options do not need to be explicitly stated anymore.
https://github.com/emscripten-core/emscripten/issues/12870

The rationale for removing these is to better allow things like setting "SHELL:-s WASM=0" in executables depending on datachannel-wasm.