### PR TITLE
Fixing rtcCreatePeerConnection

### DIFF
--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -161,10 +161,11 @@
 			if(!window.RTCPeerConnection) return 0;
 			var iceServers = [];
 			for(var i = 0; i < nIceServers; ++i) {
-			  var heap = Module['HEAPU32'];
+				var heap = Module['HEAPU32'];
 				var p = heap[pIceServers/heap.BYTES_PER_ELEMENT + i];
+				var url = UTF8ToString(p);
 				iceServers.push({
-					urls: [UTF8ToString(p)],
+					urls: [url],
 				});
 			}
 			var config = {

--- a/wasm/src/peerconnection.cpp
+++ b/wasm/src/peerconnection.cpp
@@ -25,7 +25,7 @@
 #include <stdexcept>
 
 extern "C" {
-extern int rtcCreatePeerConnection(const char **iceServers);
+extern int rtcCreatePeerConnection(const char **pIceServers, int nIceServers);
 extern void rtcDeletePeerConnection(int pc);
 extern char *rtcGetLocalDescription(int pc);
 extern char *rtcGetLocalDescriptionType(int pc);
@@ -92,8 +92,7 @@ PeerConnection::PeerConnection(const Configuration &config) {
 	ptrs.reserve(config.iceServers.size());
 	for (const string &s : config.iceServers)
 		ptrs.push_back(s.c_str());
-	ptrs.push_back(nullptr);
-	mId = rtcCreatePeerConnection(ptrs.data());
+	mId = rtcCreatePeerConnection(ptrs.data(), ptrs.size());
 	if (!mId)
 		throw std::runtime_error("WebRTC not supported");
 


### PR DESCRIPTION
Add second parameter to rtcCreatePeerConnection from the c++ side, which was missing.

Previously, nIceServers was undefined from the javascript side. What happened was since nIceServers is undefined, i < nIceServers was always false, so the for loop of rtcCreatePeerConnection was skipped.