### PR TITLE
Add DatachannelInit and Reliability for PeerConnection::createDataChannel.

### DIFF
--- a/wasm/include/rtc/peerconnection.hpp
+++ b/wasm/include/rtc/peerconnection.hpp
@@ -24,12 +24,17 @@
 #include "datachannel.hpp"
 #include "description.hpp"
 #include "common.hpp"
+#include "reliability.hpp"
 
 #include <functional>
 #include <optional>
 #include <variant>
 
 namespace rtc {
+
+struct DataChannelInit {
+	Reliability reliability = {};
+};
 
 class PeerConnection final {
 public:
@@ -62,7 +67,7 @@ public:
 
 	std::optional<Description> localDescription() const;
 
-	std::shared_ptr<DataChannel> createDataChannel(const string &label);
+	std::shared_ptr<DataChannel> createDataChannel(const string &label, DataChannelInit init = {});
 
 	void setRemoteDescription(const Description &description);
 	void addRemoteCandidate(const Candidate &candidate);

--- a/wasm/include/rtc/reliability.hpp
+++ b/wasm/include/rtc/reliability.hpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2017-2020 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef RTC_RELIABILITY_H
+#define RTC_RELIABILITY_H
+
+namespace rtc {
+// TODO: Support Type::Timed
+struct Reliability {
+	enum class Type { Reliable = 0, Rexmit };
+
+	Type type = Type::Reliable;
+	bool unordered = false;
+	int rexmit = 0;
+};
+
+} // namespace rtc
+
+#endif // RTC_PEERCONNECTION_H

--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -94,7 +94,7 @@
 			},
 
 			handleConnectionStateChange: function(peerConnection, connectionState) {
-				var stateChangeCallback =  peerConnection.rtcStateChangeCallback;
+				var stateChangeCallback = peerConnection.rtcStateChangeCallback;
 				var userPointer = peerConnection.rtcUserPointer || 0;
 				switch(connectionState) {
 					case 'new':
@@ -214,11 +214,16 @@
 			return type;
 		},
 
-		rtcCreateDataChannel: function(pc, pLabel) {
+		rtcCreateDataChannel: function(pc, pLabel, unreliable, unordered, rexmit) {
 			if(!pc) return 0;
 			var label = UTF8ToString(pLabel);
 			var peerConnection = WEBRTC.peerConnectionsMap[pc];
-			var channel = peerConnection.createDataChannel(label);
+			var datachannelInit = {};
+			if (unordered)
+				datachannelInit['ordered'] = false;
+			if (unreliable)
+				datachannelInit['maxRetransmits'] = rexmit;
+			var channel = peerConnection.createDataChannel(label, datachannelInit);
 			return WEBRTC.registerDataChannel(channel);
 		},
 

--- a/wasm/src/peerconnection.cpp
+++ b/wasm/src/peerconnection.cpp
@@ -141,7 +141,7 @@ optional<Description> PeerConnection::localDescription() const {
 	return description;
 }
 
-shared_ptr<DataChannel> PeerConnection::createDataChannel(const string &label) {
+shared_ptr<DataChannel> PeerConnection::createDataChannel(const string &label, DataChannelInit init) {
 	return std::make_shared<DataChannel>(rtcCreateDataChannel(mId, label.c_str()));
 }
 

--- a/wasm/src/peerconnection.cpp
+++ b/wasm/src/peerconnection.cpp
@@ -29,7 +29,7 @@ extern int rtcCreatePeerConnection(const char **pUrls, const char **pUsernames, 
 extern void rtcDeletePeerConnection(int pc);
 extern char *rtcGetLocalDescription(int pc);
 extern char *rtcGetLocalDescriptionType(int pc);
-extern int rtcCreateDataChannel(int pc, const char *label);
+extern int rtcCreateDataChannel(int pc, const char *label, bool unreliable, bool unordered, int rexmit);
 extern void rtcSetDataChannelCallback(int pc, void (*dataChannelCallback)(int, void *));
 extern void rtcSetLocalDescriptionCallback(int pc,
                                            void (*descriptionCallback)(const char *, const char *,
@@ -142,7 +142,11 @@ optional<Description> PeerConnection::localDescription() const {
 }
 
 shared_ptr<DataChannel> PeerConnection::createDataChannel(const string &label, DataChannelInit init) {
-	return std::make_shared<DataChannel>(rtcCreateDataChannel(mId, label.c_str()));
+	return std::make_shared<DataChannel>(rtcCreateDataChannel(mId,
+															  label.c_str(),
+															  init.reliability.type != Reliability::Type::Reliable,
+															  init.reliability.unordered,
+															  init.reliability.rexmit));
 }
 
 void PeerConnection::setRemoteDescription(const Description &description) {


### PR DESCRIPTION
Added these to support creating unordered or unreliable datachannels.