### PR TITLE
Extend iceServer API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 set(WASM_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/wasm/src)
 set(DATACHANNELS_SRC
 	${WASM_SRC_DIR}/channel.cpp
+	${WASM_SRC_DIR}/configuration.cpp
 	${WASM_SRC_DIR}/datachannel.cpp
 	${WASM_SRC_DIR}/peerconnection.cpp
 	${WASM_SRC_DIR}/websocket.cpp)

--- a/wasm/include/rtc/common.hpp
+++ b/wasm/include/rtc/common.hpp
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <variant>
 #include <vector>
@@ -33,7 +34,6 @@ using std::string;
 using binary = std::vector<byte>;
 using message_variant = std::variant<binary, string>;
 
-using std::function;
 using std::nullopt;
 
 template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };

--- a/wasm/include/rtc/configuration.hpp
+++ b/wasm/include/rtc/configuration.hpp
@@ -29,7 +29,8 @@ struct IceServer {
 	enum class Type { Stun, Turn, Dummy };
 	enum class RelayType { TurnUdp, TurnTcp, TurnTls };
 
-	// Any type
+	// Note: Contrary to libdatachannel, the URL constructor does not parse the URL.
+	// Instead, it creates a Dummy IceServer to pass the URL as-is to the browser.
 	IceServer(const string &url);
 
 	// STUN

--- a/wasm/include/rtc/configuration.hpp
+++ b/wasm/include/rtc/configuration.hpp
@@ -26,22 +26,28 @@
 namespace rtc {
 
 struct IceServer {
-	enum class Type { Stun, Turn };
-	
+	enum class Type { Stun, Turn, Dummy };
+	enum class RelayType { TurnUdp, TurnTcp, TurnTls };
+
+	// Any type
+	IceServer(const string &url);
+
 	// STUN
-	IceServer(string hostname_, uint16_t port_)
-		: hostname(std::move(hostname_)), port(port_), type(Type::Stun) {}
-	
+	IceServer(string hostname_, uint16_t port_);
+	IceServer(string hostname_, string service_);
+
 	// TURN
-	IceServer(string hostname_, uint16_t port_, string username_, string password_)
-		: hostname(std::move(hostname_)), port(port_), type(Type::Turn), username(std::move(username_)),
-      	  password(std::move(password_)) {}
+	IceServer(string hostname_, uint16_t port, string username_, string password_,
+	          RelayType relayType_ = RelayType::TurnUdp);
+	IceServer(string hostname_, string service_, string username_, string password_,
+	          RelayType relayType_ = RelayType::TurnUdp);
 
 	string hostname;
 	uint16_t port;
 	Type type;
 	string username;
 	string password;
+	RelayType relayType;
 };
 
 struct Configuration {

--- a/wasm/src/configuration.cpp
+++ b/wasm/src/configuration.cpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2017-2021 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "configuration.hpp"
+
+namespace rtc {
+
+IceServer::IceServer(const string &url) : hostname(url), port(0), type(Type::Dummy) {}
+
+IceServer::IceServer(string hostname_, uint16_t port_)
+    : hostname(std::move(hostname_)), port(port_), type(Type::Stun) {}
+
+IceServer::IceServer(string hostname_, string service_)
+    : hostname(std::move(hostname_)), type(Type::Stun) {
+	try {
+		port = uint16_t(std::stoul(service_));
+	} catch (...) {
+		throw std::invalid_argument("Invalid ICE server port: " + service_);
+	}
+}
+
+IceServer::IceServer(string hostname_, uint16_t port_, string username_, string password_,
+                     RelayType relayType_)
+    : hostname(std::move(hostname_)), port(port_), type(Type::Turn), username(std::move(username_)),
+      password(std::move(password_)), relayType(relayType_) {}
+
+IceServer::IceServer(string hostname_, string service_, string username_, string password_,
+                     RelayType relayType_)
+    : hostname(std::move(hostname_)), type(Type::Turn), username(std::move(username_)),
+      password(std::move(password_)), relayType(relayType_) {
+	try {
+		port = uint16_t(std::stoul(service_));
+	} catch (...) {
+		throw std::invalid_argument("Invalid ICE server port: " + service_);
+	}
+}
+
+} // namespace rtc


### PR DESCRIPTION
This PR extends the `IceServer` API to match the one of libdatachannel.