### PR TITLE
Fix warning "linker setting ignored during compilation"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,13 +30,12 @@ target_include_directories(datachannel-wasm PUBLIC
 target_include_directories(datachannel-wasm PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/wasm/include/rtc)
 
-set(WASM_OPTS "")
-
-if(EXPORT_DYNCALL)
-  list(APPEND WASM_OPTS "SHELL:-s EXPORTED_RUNTIME_METHODS=[\"dynCall\"]")
-endif()
-
-target_compile_options(datachannel-wasm PUBLIC ${WASM_OPTS})
-target_link_options(datachannel-wasm PUBLIC ${WASM_OPTS}
+target_link_options(datachannel-wasm PUBLIC
 	"SHELL:--js-library ${CMAKE_CURRENT_SOURCE_DIR}/wasm/js/webrtc.js"
 	"SHELL:--js-library ${CMAKE_CURRENT_SOURCE_DIR}/wasm/js/websocket.js")
+
+if(EXPORT_DYNCALL)
+	target_link_options(datachannel-wasm PUBLIC
+		"SHELL:-s EXPORTED_RUNTIME_METHODS=[\"dynCall\"]")
+endif()
+


### PR DESCRIPTION
This PR removes `EXPORTED_RUNTIME_METHODS` from compile options while keeping it in link options.