### PR TITLE
Replace dynamic dynCall by makeDynCall macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ project(datachannel-wasm
 	VERSION 0.2.0
 	LANGUAGES CXX)
 
-option(EXPORT_DYNCALL "Export runtime method dynCall" ON)
-
 if(NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
 	message(FATAL_ERROR "datachannel-wasm must be compiled with Emscripten.")
 endif()
@@ -33,9 +31,4 @@ target_include_directories(datachannel-wasm PRIVATE
 target_link_options(datachannel-wasm PUBLIC
 	"SHELL:--js-library ${CMAKE_CURRENT_SOURCE_DIR}/wasm/js/webrtc.js"
 	"SHELL:--js-library ${CMAKE_CURRENT_SOURCE_DIR}/wasm/js/websocket.js")
-
-if(EXPORT_DYNCALL)
-	target_link_options(datachannel-wasm PUBLIC
-		"SHELL:-s EXPORTED_RUNTIME_METHODS=[\"dynCall\"]")
-endif()
 

--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -79,7 +79,7 @@
 						var pType = WEBRTC.allocUTF8FromString(desc.type);
 						var callback =  peerConnection.rtcDescriptionCallback;
 						var userPointer = peerConnection.rtcUserPointer || 0;
-						Module['dynCall']('viii', callback, [pSdp, pType, userPointer]);
+						{{{ makeDynCall('viii', 'callback') }}} (pSdp, pType, userPointer);
 						_free(pSdp);
 						_free(pType);
 					});
@@ -92,7 +92,7 @@
 				var pSdpMid = WEBRTC.allocUTF8FromString(candidate.sdpMid);
 				var candidateCallback =  peerConnection.rtcCandidateCallback;
 				var userPointer = peerConnection.rtcUserPointer || 0;
-				Module['dynCall']('viii', candidateCallback, [pCandidate, pSdpMid, userPointer]);
+				{{{ makeDynCall('viii', 'candidateCallback') }}} (pCandidate, pSdpMid, userPointer);
 				_free(pCandidate);
 				_free(pSdpMid);
 			},
@@ -111,7 +111,7 @@
 				if(connectionState in map) {
 					var stateChangeCallback = peerConnection.rtcStateChangeCallback;
 					var userPointer = peerConnection.rtcUserPointer || 0;
-					Module['dynCall']('vii', stateChangeCallback, [map[connectionState], userPointer]);
+					{{{ makeDynCall('vii', 'stateChangeCallback') }}} (map[connectionState], userPointer);
 				}
 			},
 
@@ -126,7 +126,7 @@
 				if(iceGatheringState in map) {
 					var gatheringStateChangeCallback = peerConnection.rtcGatheringStateChangeCallback;
 					var userPointer = peerConnection.rtcUserPointer || 0;
-					Module['dynCall']('vii', gatheringStateChangeCallback, [map[iceGatheringState], userPointer]);
+					{{{ makeDynCall('vii', 'gatheringStateChangeCallback') }}} (map[iceGatheringState], userPointer);
 				}
 			},
 
@@ -143,7 +143,7 @@
 				if(signalingState in map) {
 					var signalingStateChangeCallback = peerConnection.rtcSignalingStateChangeCallback;
 					var userPointer = peerConnection.rtcUserPointer || 0;
-					Module['dynCall']('vii', signalingStateChangeCallback, [map[signalingState], userPointer]);
+					{{{ makeDynCall('vii', 'signalingStateChangeCallback') }}} (map[signalingState], userPointer);
 				}
 			},
 		},
@@ -159,7 +159,7 @@
 				var username = UTF8ToString(pUsername);
 				var pPassword = heap[pPasswords/heap.BYTES_PER_ELEMENT + i];
 				var password = UTF8ToString(pPassword);
-				if (username === "") {
+				if (username == "") {
 					iceServers.push({
 						urls: [url],
 					});
@@ -256,7 +256,7 @@
 				if(peerConnection.rtcUserDeleted) return;
 				var dc = WEBRTC.registerDataChannel(evt.channel);
 				var userPointer = peerConnection.rtcUserPointer || 0;
-				Module['dynCall']('vii', dataChannelCallback, [dc, userPointer]);
+				{{{ makeDynCall('vii', 'dataChannelCallback') }}} (dc, userPointer);
 			};
 		},
 
@@ -337,7 +337,7 @@
 			var cb = function() {
 				if(dataChannel.rtcUserDeleted) return;
 				var userPointer = dataChannel.rtcUserPointer || 0;
-				Module['dynCall']('vi', openCallback, [userPointer]);
+				{{{ makeDynCall('vi', 'openCallback') }}} (userPointer);
 			};
 			dataChannel.onopen = cb;
 			if(dataChannel.readyState == 'open') setTimeout(cb, 0);
@@ -349,7 +349,7 @@
 				if(dataChannel.rtcUserDeleted) return;
 				var userPointer = dataChannel.rtcUserPointer || 0;
 				var pError = evt.message ? WEBRTC.allocUTF8FromString(evt.message) : 0;
-				Module['dynCall']('vii', errorCallback, [pError, userPointer]);
+				{{{ makeDynCall('vii', 'errorCallback') }}} (pError, userPointer);
 				_free(pError);
 			};
 			dataChannel.onerror = cb;
@@ -362,7 +362,7 @@
 				var userPointer = dataChannel.rtcUserPointer || 0;
 				if(typeof evt.data == 'string') {
 					var pStr = WEBRTC.allocUTF8FromString(evt.data);
-					Module['dynCall']('viii', messageCallback, [pStr, -1, userPointer]);
+					{{{ makeDynCall('viii', 'messageCallback') }}} (pStr, -1, userPointer);
 					_free(pStr);
 				} else {
 					var byteArray = new Uint8Array(evt.data);
@@ -370,14 +370,14 @@
 					var pBuffer = _malloc(size);
 					var heapBytes = new Uint8Array(Module['HEAPU8'].buffer, pBuffer, size);
 					heapBytes.set(byteArray);
-					Module['dynCall']('viii', messageCallback, [pBuffer, size, userPointer]);
+					{{{ makeDynCall('viii', 'messageCallback') }}} (pBuffer, size, userPointer);
 					_free(pBuffer);
 				}
 			};
 			dataChannel.onclose = function() {
 				if(dataChannel.rtcUserDeleted) return;
 				var userPointer = dataChannel.rtcUserPointer || 0;
-				Module['dynCall']('viii', messageCallback, [0, 0, userPointer]);
+				{{{ makeDynCall('viii', 'messageCallback') }}} (0, 0, userPointer);
 			};
 		},
 
@@ -386,7 +386,7 @@
 			var cb = function(evt) {
 				if(dataChannel.rtcUserDeleted) return;
 				var userPointer = dataChannel.rtcUserPointer || 0;
-					Module['dynCall']('vi', bufferedAmountLowCallback, [userPointer]);
+				{{{ makeDynCall('vi', 'bufferedAmountLowCallback') }}} (userPointer);
 			};
 			dataChannel.onbufferedamountlow = cb;
 		},

--- a/wasm/js/websocket.js
+++ b/wasm/js/websocket.js
@@ -61,7 +61,7 @@
 			var cb = function() {
 				if(webSocket.rtcUserDeleted) return;
 				var userPointer = webSocket.rtcUserPointer || 0;
-				Module['dynCall']('vi', openCallback, [userPointer]);
+				{{{ makeDynCall('vi', 'openCallback') }}} (userPointer);
 			};
 			webSocket.onopen = cb;
 			if(webSocket.readyState == 1) setTimeout(cb, 0);
@@ -72,7 +72,7 @@
 			var cb = function() {
 				if(webSocket.rtcUserDeleted) return;
 				var userPointer = webSocket.rtcUserPointer || 0;
-				Module['dynCall']('vii', errorCallback, [0, userPointer]);
+        {{{ makeDynCall('vii', 'errorCallback') }}} (0, userPointer);
 			};
 			webSocket.onerror = cb;
 		},
@@ -84,7 +84,7 @@
 				if(typeof evt.data == 'string') {
 					var pStr = WEBSOCKET.allocUTF8FromString(evt.data);
 					var userPointer = webSocket.rtcUserPointer || 0;
-					Module['dynCall']('viii', messageCallback, [pStr, -1, userPointer]);
+					{{{ makeDynCall('viii', 'messageCallback') }}} (pStr, -1, userPointer);
 					_free(pStr);
 				} else {
 					var byteArray = new Uint8Array(evt.data);
@@ -93,14 +93,14 @@
 					var heapBytes = new Uint8Array(Module['HEAPU8'].buffer, pBuffer, size);
 					heapBytes.set(byteArray);
 					var userPointer = webSocket.rtcUserPointer || 0;
-					Module['dynCall']('viii', messageCallback, [pBuffer, size, userPointer]);
+					{{{ makeDynCall('viii', 'messageCallback') }}} (pBuffer, size, userPointer);
 					_free(pBuffer);
 				}
 			};
 			webSocket.onclose = function() {
 				if(webSocket.rtcUserDeleted) return;
 				var userPointer = webSocket.rtcUserPointer || 0;
-				Module['dynCall']('viii', messageCallback, [0, 0, userPointer]);
+				{{{ makeDynCall('viii', 'messageCallback') }}} (0, 0, userPointer);
 			};
 		},
 


### PR DESCRIPTION
It appears `dynCall` has been converted into a library function in https://github.com/emscripten-core/emscripten/issues/12002 therefore datachannel-wasm should add an explicit dependency on `'$dynCall'` to ensure it is present at runtime.

However, it seems better to remove the reliance on the `dynCall` API entirely. This PR replaces dynamic `dynCall` usage by the `makeDynCall` macro, as the macro looks widely used in emscripten JS libraries and is de-facto public as explained in https://github.com/emscripten-core/emscripten/pull/12732. It removes the dependency on the runtime method and should perform better.

Fixes the possible need for `-sDYNCALLS=1` described in https://github.com/paullouisageneau/datachannel-wasm/issues/38