### PR TITLE
Close RTCPeerConnection objects before deleting

### DIFF
--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -202,6 +202,7 @@
 		rtcDeletePeerConnection: function(pc) {
 			var peerConnection = WEBRTC.peerConnectionsMap[pc];
 			if(peerConnection) {
+				peerConnection.close();
 				peerConnection.rtcUserDeleted = true;
 				delete WEBRTC.peerConnectionsMap[pc];
 			}


### PR DESCRIPTION
This helps the Chromium garbage collection system clean up resources. If we don't do this, and we create and destroy too many instances, we get this error: Uncaught DOMException: Failed to construct 'RTCPeerConnection': Cannot create so many PeerConnections

Note that there is a separate bug with Chromium that has existed for 5+ years. The bug is that garbage collection does not get triggered at all for lots of deleted RTCPeerConnections: https://bugs.chromium.org/p/chromium/issues/detail?id=825576

People have worked around this Chromium bug using queueMicrotask(). That correctly works around the issue, but only if the RTCPeerConnection was closed before deleting.