### PR TITLE
Support SharedArrayBuffer heap

### DIFF
--- a/wasm/include/rtc/common.hpp
+++ b/wasm/include/rtc/common.hpp
@@ -24,6 +24,7 @@
 #define RTC_INCLUDE_H
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <stdexcept>

--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -435,7 +435,13 @@
 			if(dataChannel.readyState != 'open') return -1;
 			if(size >= 0) {
 				var heapBytes = new Uint8Array(Module['HEAPU8'].buffer, pBuffer, size);
-				dataChannel.send(heapBytes);
+				if(heapBytes.buffer instanceof ArrayBuffer) {
+					dataChannel.send(heapBytes);
+				} else {
+					var byteArray = new Uint8Array(new ArrayBuffer(size));
+					byteArray.set(heapBytes);
+					dataChannel.send(byteArray);
+				}
 				return size;
 			} else {
 				var str = UTF8ToString(pBuffer);

--- a/wasm/js/websocket.js
+++ b/wasm/js/websocket.js
@@ -109,7 +109,13 @@
 			if(webSocket.readyState != 1) return -1;
 			if(size >= 0) {
 				var heapBytes = new Uint8Array(Module['HEAPU8'].buffer, pBuffer, size);
-				webSocket.send(heapBytes);
+				if(heapBytes.buffer instanceof ArrayBuffer) {
+					webSocket.send(heapBytes);
+				} else {
+					var byteArray = new Uint8Array(new ArrayBuffer(size));
+					byteArray.set(heapBytes);
+					webSocket.send(byteArray);
+				}
 				return size;
 			} else {
 				var str = UTF8ToString(pBuffer);


### PR DESCRIPTION
This PR adds a copy to an `ArrayBuffer` before sending binary messages if the heap is a `SharedArrayBuffer`.

Should fix https://github.com/paullouisageneau/datachannel-wasm/issues/48