### PR TITLE
Refactor reliability API

### DIFF
--- a/wasm/include/rtc/datachannel.hpp
+++ b/wasm/include/rtc/datachannel.hpp
@@ -25,6 +25,7 @@
 
 #include "channel.hpp"
 #include "common.hpp"
+#include "reliability.hpp"
 
 namespace rtc {
 
@@ -41,6 +42,7 @@ public:
 	bool isClosed() const override;
 	size_t bufferedAmount() const override;
 	string label() const;
+	Reliability reliability() const;
 
 	void setBufferedAmountLowThreshold(size_t amount) override;
 

--- a/wasm/include/rtc/reliability.hpp
+++ b/wasm/include/rtc/reliability.hpp
@@ -30,11 +30,18 @@
 namespace rtc {
 
 struct Reliability {
-	enum class Type { Reliable = 0, Rexmit, Timed };
-
-	Type type = Type::Reliable;
+	// It true, the channel does not enforce message ordering and out-of-order delivery is allowed
 	bool unordered = false;
-	variant<int, std::chrono::milliseconds> rexmit = 0;
+
+	// If both maxPacketLifeTime or maxRetransmits are unset, the channel is reliable.
+	// If either maxPacketLifeTime or maxRetransmits is set, the channel is unreliable.
+	// (The settings are exclusive so both maxPacketLifetime and maxRetransmits must not be set.)
+
+	// Time window during which transmissions and retransmissions may occur
+	optional<std::chrono::milliseconds> maxPacketLifeTime;
+
+	// Maximum number of retransmissions that are attempted
+	optional<unsigned int> maxRetransmits;
 };
 
 } // namespace rtc

--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -301,7 +301,7 @@
 			peerConnection.rtcStateChangeCallback = stateChangeCallback;
 		},
 
-    rtcSetIceStateChangeCallback: function(pc, iceStateChangeCallback) {
+		rtcSetIceStateChangeCallback: function(pc, iceStateChangeCallback) {
 			if(!pc) return;
 			var peerConnection = WEBRTC.peerConnectionsMap[pc];
 			peerConnection.rtcIceStateChangeCallback = iceStateChangeCallback;
@@ -356,12 +356,32 @@
 		},
 
 		rtcGetDataChannelLabel: function(dc, pBuffer, size) {
+			if(!dc) return 0;
 			var label = WEBRTC.dataChannelsMap[dc].label;
 			stringToUTF8(label, pBuffer, size);
 			return lengthBytesUTF8(label);
 		},
 
+		rtcGetDataChannelUnordered: function(dc) {
+			if(!dc) return 0;
+			var dataChannel = WEBRTC.dataChannelsMap[dc];
+			return dataChannel.ordered ? 0 : 1;
+		},
+
+		rtcGetDataChannelMaxPacketLifeTime: function(dc) {
+			if(!dc) return -1;
+			var dataChannel = WEBRTC.dataChannelsMap[dc];
+			return dataChannel.maxPacketLifeTime !== null ? dataChannel.maxPacketLifeTime : -1;
+		},
+
+		rtcGetDataChannelMaxRetransmits: function(dc) {
+			if(!dc) return -1;
+			var dataChannel = WEBRTC.dataChannelsMap[dc];
+			return dataChannel.maxRetransmits !== null ? dataChannel.maxRetransmits : -1;
+		},
+
 		rtcSetOpenCallback: function(dc, openCallback) {
+			if(!dc) return;
 			var dataChannel = WEBRTC.dataChannelsMap[dc];
 			var cb = function() {
 				if(dataChannel.rtcUserDeleted) return;
@@ -373,6 +393,7 @@
 		},
 
 		rtcSetErrorCallback: function(dc, errorCallback) {
+			if(!dc) return;
 			var dataChannel = WEBRTC.dataChannelsMap[dc];
 			var cb = function(evt) {
 				if(dataChannel.rtcUserDeleted) return;
@@ -385,6 +406,7 @@
 		},
 
 		rtcSetMessageCallback: function(dc, messageCallback) {
+			if(!dc) return;
 			var dataChannel = WEBRTC.dataChannelsMap[dc];
 			dataChannel.onmessage = function(evt) {
 				if(dataChannel.rtcUserDeleted) return;
@@ -411,6 +433,7 @@
 		},
 
 		rtcSetBufferedAmountLowCallback: function(dc, bufferedAmountLowCallback) {
+			if(!dc) return;
 			var dataChannel = WEBRTC.dataChannelsMap[dc];
 			var cb = function(evt) {
 				if(dataChannel.rtcUserDeleted) return;
@@ -421,16 +444,19 @@
 		},
 
 		rtcGetBufferedAmount: function(dc) {
+			if(!dc) return;
 			var dataChannel = WEBRTC.dataChannelsMap[dc];
 			return dataChannel.bufferedAmount;
 		},
 
 		rtcSetBufferedAmountLowThreshold: function(dc, threshold) {
+			if(!dc) return;
 			var dataChannel = WEBRTC.dataChannelsMap[dc];
 			dataChannel.bufferedAmountLowThreshold = threshold;
 		},
 
 		rtcSendMessage: function(dc, pBuffer, size) {
+			if(!dc) return;
 			var dataChannel = WEBRTC.dataChannelsMap[dc];
 			if(dataChannel.readyState != 'open') return -1;
 			if(size >= 0) {


### PR DESCRIPTION
This PR refactors the reliability API to align it on libdatachannel and adds a getter on `DataChannel`.

Fixes https://github.com/paullouisageneau/datachannel-wasm/issues/50