### PR TITLE
Align with libdatachannel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(DATACHANNELS_SRC
 	${WASM_SRC_DIR}/configuration.cpp
 	${WASM_SRC_DIR}/description.cpp
 	${WASM_SRC_DIR}/datachannel.cpp
+	${WASM_SRC_DIR}/global.cpp
 	${WASM_SRC_DIR}/peerconnection.cpp
 	${WASM_SRC_DIR}/websocket.cpp)
 

--- a/wasm/include/rtc/candidate.hpp
+++ b/wasm/include/rtc/candidate.hpp
@@ -25,8 +25,6 @@
 
 #include "common.hpp"
 
-#include <iostream>
-
 namespace rtc {
 
 class Candidate {

--- a/wasm/include/rtc/common.hpp
+++ b/wasm/include/rtc/common.hpp
@@ -20,11 +20,12 @@
  * SOFTWARE.
  */
 
-#ifndef RTC_INCLUDE_H
-#define RTC_INCLUDE_H
+#ifndef RTC_COMMON_H
+#define RTC_COMMON_H
 
 #include <cstddef>
 #include <cstdint>
+#include <iostream>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -52,9 +53,11 @@ using std::uint32_t;
 using std::uint64_t;
 using std::uint8_t;
 
-template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template <class... Ts> struct overloaded : Ts... {
+	using Ts::operator()...;
+};
 template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 } // namespace rtc
 
-#endif // RTC_INCLUDE_H
+#endif // RTC_COMMON_H

--- a/wasm/include/rtc/description.hpp
+++ b/wasm/include/rtc/description.hpp
@@ -25,8 +25,6 @@
 
 #include "common.hpp"
 
-#include <iostream>
-
 namespace rtc {
 
 class Description {

--- a/wasm/include/rtc/global.hpp
+++ b/wasm/include/rtc/global.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2022 Paul-Louis Ageneau
+ * Copyright (c) 2017-2024 Paul-Louis Ageneau
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,14 +20,36 @@
  * SOFTWARE.
  */
 
-#ifndef RTC_H
-#define RTC_H
+#ifndef RTC_GLOBAL_H
+#define RTC_GLOBAL_H
 
 #include "common.hpp"
-#include "global.hpp"
 
-#include "datachannel.hpp"
-#include "peerconnection.hpp"
-#include "websocket.hpp"
+#include <future>
+#include <iostream>
 
-#endif // RTC_H
+namespace rtc {
+
+enum class LogLevel {
+	None = 0,
+	Fatal = 1,
+	Error = 2,
+	Warning = 3,
+	Info = 4,
+	Debug = 5,
+	Verbose = 6
+};
+
+typedef std::function<void(LogLevel level, string message)> LogCallback;
+
+// Dummy function for compatibility with libdatachannel
+void InitLogger(LogLevel level, LogCallback callback = nullptr);
+void Preload();
+std::shared_future<void> Cleanup();
+
+std::ostream &operator<<(std::ostream &out, LogLevel level);
+
+} // namespace rtc
+
+#endif
+

--- a/wasm/include/rtc/peerconnection.hpp
+++ b/wasm/include/rtc/peerconnection.hpp
@@ -130,6 +130,11 @@ private:
 	static void SignalingStateChangeCallback(int state, void *ptr);
 };
 
+std::ostream &operator<<(std::ostream &out, PeerConnection::State state);
+std::ostream &operator<<(std::ostream &out, PeerConnection::IceState state);
+std::ostream &operator<<(std::ostream &out, PeerConnection::GatheringState state);
+std::ostream &operator<<(std::ostream &out, PeerConnection::SignalingState state);
+
 } // namespace rtc
 
 #endif // RTC_PEERCONNECTION_H

--- a/wasm/include/rtc/peerconnection.hpp
+++ b/wasm/include/rtc/peerconnection.hpp
@@ -75,6 +75,8 @@ public:
 	PeerConnection(const Configuration &config);
 	~PeerConnection();
 
+	void close();
+
 	State state() const;
 	IceState iceState() const;
 	GatheringState gatheringState() const;

--- a/wasm/include/rtc/websocket.hpp
+++ b/wasm/include/rtc/websocket.hpp
@@ -31,6 +31,13 @@ namespace rtc {
 // WebSocket wrapper for emscripten
 class WebSocket final : public Channel {
 public:
+	enum class State : int {
+		Connecting = 0,
+		Open = 1,
+		Closing = 2,
+		Closed = 3,
+	};
+
 	WebSocket();
 	~WebSocket();
 
@@ -39,8 +46,12 @@ public:
 	bool send(message_variant data) override;
 	bool send(const byte *data, size_t size) override;
 
+	State readyState() const;
+
 	bool isOpen() const override;
 	bool isClosed() const override;
+
+	optional<string> url() const;
 
 private:
 	void triggerOpen() override;
@@ -52,6 +63,8 @@ private:
 	static void ErrorCallback(const char *error, void *ptr);
 	static void MessageCallback(const char *data, int size, void *ptr);
 };
+
+std::ostream &operator<<(std::ostream &out, WebSocket::State state);
 
 } // namespace rtc
 

--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -444,7 +444,7 @@
 		},
 
 		rtcGetBufferedAmount: function(dc) {
-			if(!dc) return;
+			if(!dc) return 0;
 			var dataChannel = WEBRTC.dataChannelsMap[dc];
 			return dataChannel.bufferedAmount;
 		},
@@ -456,7 +456,7 @@
 		},
 
 		rtcSendMessage: function(dc, pBuffer, size) {
-			if(!dc) return;
+			if(!dc) return -1;
 			var dataChannel = WEBRTC.dataChannelsMap[dc];
 			if(dataChannel.readyState != 'open') return -1;
 			if(size >= 0) {

--- a/wasm/js/websocket.js
+++ b/wasm/js/websocket.js
@@ -57,6 +57,7 @@
 		},
 
 		wsSetOpenCallback: function(ws, openCallback) {
+			if (!ws) return;
 			var webSocket = WEBSOCKET.map[ws];
 			var cb = function() {
 				if(webSocket.rtcUserDeleted) return;
@@ -68,6 +69,7 @@
 		},
 
  		wsSetErrorCallback: function(ws, errorCallback) {
+			if (!ws) return;
 			var webSocket = WEBSOCKET.map[ws];
 			var cb = function() {
 				if(webSocket.rtcUserDeleted) return;
@@ -78,6 +80,7 @@
 		},
 
 		wsSetMessageCallback: function(ws, messageCallback) {
+			if (!ws) return;
 			var webSocket = WEBSOCKET.map[ws];
 			webSocket.onmessage = function(evt) {
 				if(webSocket.rtcUserDeleted) return;
@@ -105,6 +108,7 @@
 		},
 
 		wsSendMessage: function(ws, pBuffer, size) {
+			if (!ws) return -1;
 			var webSocket = WEBSOCKET.map[ws];
 			if(webSocket.readyState != 1) return -1;
 			if(size >= 0) {
@@ -122,6 +126,20 @@
 				webSocket.send(str);
 				return lengthBytesUTF8(str);
 			}
+		},
+
+		wsGetWebSocketUrl: function(ws) {
+			if(!ws) return 0;
+			var webSocket = WEBSOCKET.map[ws];
+			var url = WEBRTC.allocUTF8FromString(webSocket.url);
+			// url should be freed later in c++.
+			return url;
+		},
+
+		wsGetWebSocketState: function(ws) {
+			if(!ws) return WebSocket.CLOSED;
+			var webSocket = WEBSOCKET.map[ws];
+			return webSocket.readyState;
 		},
 
 		wsSetUserPointer: function(ws, ptr) {

--- a/wasm/src/global.cpp
+++ b/wasm/src/global.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2022 Paul-Louis Ageneau
+ * Copyright (c) 2017-2024 Paul-Louis Ageneau
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,14 +20,50 @@
  * SOFTWARE.
  */
 
-#ifndef RTC_H
-#define RTC_H
-
-#include "common.hpp"
 #include "global.hpp"
 
-#include "datachannel.hpp"
-#include "peerconnection.hpp"
-#include "websocket.hpp"
+namespace rtc {
 
-#endif // RTC_H
+void InitLogger([[maybe_unused]] LogLevel level, [[maybe_unused]] LogCallback callback) {
+	// Dummy
+}
+
+void Preload() {
+	// Dummy
+}
+
+std::shared_future<void> Cleanup() {
+	// Dummy
+	std::promise<void> p;
+	p.set_value();
+	return p.get_future();
+}
+
+std::ostream &operator<<(std::ostream &out, LogLevel level) {
+	switch (level) {
+	case LogLevel::Fatal:
+		out << "fatal";
+		break;
+	case LogLevel::Error:
+		out << "error";
+		break;
+	case LogLevel::Warning:
+		out << "warning";
+		break;
+	case LogLevel::Info:
+		out << "info";
+		break;
+	case LogLevel::Debug:
+		out << "debug";
+		break;
+	case LogLevel::Verbose:
+		out << "verbose";
+		break;
+	default:
+		out << "none";
+		break;
+	}
+	return out;
+}
+
+} // namespace rtc

--- a/wasm/src/peerconnection.cpp
+++ b/wasm/src/peerconnection.cpp
@@ -154,7 +154,14 @@ PeerConnection::PeerConnection(const Configuration &config) {
 	rtcSetSignalingStateChangeCallback(mId, SignalingStateChangeCallback);
 }
 
-PeerConnection::~PeerConnection() { rtcDeletePeerConnection(mId); }
+PeerConnection::~PeerConnection() { close(); }
+
+void DataChannel::close() {
+	if (mId) {
+		rtcDeletePeerConnection(mId);
+		mId = 0;
+	}
+}
 
 PeerConnection::State PeerConnection::state() const { return mState; }
 
@@ -165,6 +172,9 @@ PeerConnection::GatheringState PeerConnection::gatheringState() const { return m
 PeerConnection::SignalingState PeerConnection::signalingState() const { return mSignalingState; }
 
 optional<Description> PeerConnection::localDescription() const {
+	if (!mId)
+		return std::nullopt;
+
 	char *sdp = rtcGetLocalDescription(mId);
 	char *type = rtcGetLocalDescriptionType(mId);
 	if (!sdp || !type) {
@@ -179,6 +189,9 @@ optional<Description> PeerConnection::localDescription() const {
 }
 
 optional<Description> PeerConnection::remoteDescription() const {
+	if (!mId)
+		return std::nullopt;
+
 	char *sdp = rtcGetRemoteDescription(mId);
 	char *type = rtcGetRemoteDescriptionType(mId);
 	if (!sdp || !type) {
@@ -194,6 +207,9 @@ optional<Description> PeerConnection::remoteDescription() const {
 
 shared_ptr<DataChannel> PeerConnection::createDataChannel(const string &label,
                                                           DataChannelInit init) {
+	if (!mId)
+		throw std::runtime_error("Peer connection is closed");
+
 	const Reliability &reliability = init.reliability;
 	if (reliability.maxPacketLifeTime && reliability.maxRetransmits)
 		throw std::invalid_argument("Both maxPacketLifeTime and maxRetransmits are set");
@@ -207,10 +223,16 @@ shared_ptr<DataChannel> PeerConnection::createDataChannel(const string &label,
 }
 
 void PeerConnection::setRemoteDescription(const Description &description) {
+	if (!mId)
+		throw std::runtime_error("Peer connection is closed");
+
 	rtcSetRemoteDescription(mId, string(description).c_str(), description.typeString().c_str());
 }
 
 void PeerConnection::addRemoteCandidate(const Candidate &candidate) {
+	if (!mId)
+		throw std::runtime_error("Peer connection is closed");
+
 	rtcAddRemoteCandidate(mId, candidate.candidate().c_str(), candidate.mid().c_str());
 }
 

--- a/wasm/src/peerconnection.cpp
+++ b/wasm/src/peerconnection.cpp
@@ -302,4 +302,112 @@ void PeerConnection::triggerSignalingStateChange(SignalingState state) {
 	if (mSignalingStateChangeCallback)
 		mSignalingStateChangeCallback(state);
 }
+
+std::ostream &operator<<(std::ostream &out, PeerConnection::State state) {
+	using State = PeerConnection::State;
+	const char *str;
+	switch (state) {
+	case State::New:
+		str = "new";
+		break;
+	case State::Connecting:
+		str = "connecting";
+		break;
+	case State::Connected:
+		str = "connected";
+		break;
+	case State::Disconnected:
+		str = "disconnected";
+		break;
+	case State::Failed:
+		str = "failed";
+		break;
+	case State::Closed:
+		str = "closed";
+		break;
+	default:
+		str = "unknown";
+		break;
+	}
+	return out << str;
+}
+
+std::ostream &operator<<(std::ostream &out, PeerConnection::IceState state) {
+	using IceState = PeerConnection::IceState;
+	const char *str;
+	switch (state) {
+	case IceState::New:
+		str = "new";
+		break;
+	case IceState::Checking:
+		str = "checking";
+		break;
+	case IceState::Connected:
+		str = "connected";
+		break;
+	case IceState::Completed:
+		str = "completed";
+		break;
+	case IceState::Failed:
+		str = "failed";
+		break;
+	case IceState::Disconnected:
+		str = "disconnected";
+		break;
+	case IceState::Closed:
+		str = "closed";
+		break;
+	default:
+		str = "unknown";
+		break;
+	}
+	return out << str;
+}
+
+std::ostream &operator<<(std::ostream &out, PeerConnection::GatheringState state) {
+	using GatheringState = PeerConnection::GatheringState;
+	const char *str;
+	switch (state) {
+	case GatheringState::New:
+		str = "new";
+		break;
+	case GatheringState::InProgress:
+		str = "in-progress";
+		break;
+	case GatheringState::Complete:
+		str = "complete";
+		break;
+	default:
+		str = "unknown";
+		break;
+	}
+	return out << str;
+}
+
+std::ostream &operator<<(std::ostream &out, PeerConnection::SignalingState state) {
+	using SignalingState = PeerConnection::SignalingState;
+	const char *str;
+	switch (state) {
+	case SignalingState::Stable:
+		str = "stable";
+		break;
+	case SignalingState::HaveLocalOffer:
+		str = "have-local-offer";
+		break;
+	case SignalingState::HaveRemoteOffer:
+		str = "have-remote-offer";
+		break;
+	case SignalingState::HaveLocalPranswer:
+		str = "have-local-pranswer";
+		break;
+	case SignalingState::HaveRemotePranswer:
+		str = "have-remote-pranswer";
+		break;
+	default:
+		str = "unknown";
+		break;
+	}
+	return out << str;
+}
+
 } // namespace rtc


### PR DESCRIPTION
This PR aligns the API with libdatachannel:
- Add dummy `InitLogger` function
- Add `PeerConnection::close` method
- Add ostream << operators for `PeerConnection` states
- Add `readyState` and `url` to `WebSocket`

Fixes https://github.com/paullouisageneau/datachannel-wasm/issues/56