### PR TITLE
Fixed the PeerConnection::close() implementation.

### DIFF
--- a/wasm/src/peerconnection.cpp
+++ b/wasm/src/peerconnection.cpp
@@ -156,7 +156,7 @@ PeerConnection::PeerConnection(const Configuration &config) {
 
 PeerConnection::~PeerConnection() { close(); }
 
-void DataChannel::close() {
+void PeerConnection::close() {
 	if (mId) {
 		rtcDeletePeerConnection(mId);
 		mId = 0;


### PR DESCRIPTION
The wrong class qualifier was used.